### PR TITLE
Disable autoscale on deployment level

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,10 +29,7 @@ v0.5 scaling
 * [x] Introduce another deployment status - `SATURATED` to indicate that we don't have
     enough resources for it
 * [x] Need a way to expose resource saturation level (how many CPUs are lacking)
-* [ ] Consider replacing DeploymentSpec with PodSpec/PodLabels/PodAnnotations 
-* [ ] Consider getting all the pods to estimate uptime/last scale event
-* [ ] Consider using number of messages in all estimates instead of `projected lag time`
-* [ ] Per-deployment auto-scaling pause
+* [x] Per-deployment auto-scaling pause
 * [ ] Verify that scaling works with multi-container pods
 
 v0.6  - observability
@@ -43,6 +40,10 @@ v0.6  - observability
 
 v0.7
 * [ ] Verify that HA mode works
+* [ ] Verify that system operates as expected when autoscaling is disabled 
+* [ ] Consider replacing DeploymentSpec with PodSpec/PodLabels/PodAnnotations 
+* [ ] Consider using number of messages in all estimates instead of `projected lag time`
+* [ ] Add totalMaxAllowed which will limit total number of cores available for the consumer
 * [ ] Recreate deployments from scratch, if any of the immutable fields were changed in the deploymentSpec
       Now, it requires manual deleting of all deployments.
 * [ ] Add ignore list of container names (do not do anything with sidecars)
@@ -58,11 +59,11 @@ Unsorted
 * [ ] [Feature] call webhooks on scaling events
 * [ ] [Feature] Vertical auto-scaling of balanced workloads (single deployment)
 * [ ] [Feature] Fully dynamic resource allocations based on historic data
-* [ ] [Feature] ? Add totalMaxAllowed which will limit total number of cores available for the consumer
 * [ ] [Feature] ? consider adding support for VPA/HPA 
 * [ ] [Feature] ? Use `scale` as a way to pause/resume the consumer
 * [ ] [Feature] ? Tool for operations `consumerctl stop/start consumer`
 * [ ] [Feature] ? Ability to set additional deployment-level annotations/labels ?
+* [ ] [Feature] ? Consider getting all the pods to estimate uptime and avoid to frequent restarts
 * [ ] [Feature] Implement second metrics provider (Kafka)
 * [ ] [Feature] scale up without restart [blocked](https://github.com/kubernetes/kubernetes/issues/5774)
 * [ ] [Feature] Get kafka lag directly from the prometheus [blocked](https://cwiki.apache.org/confluence/display/KAFKA/489%3A+Kafka+Consumer+Record+Latency+Metric)

--- a/controllers/consumer_controller_test.go
+++ b/controllers/consumer_controller_test.go
@@ -71,7 +71,50 @@ func TestNewConsumerOperator(t *testing.T) {
 				Paused:   testInt32ToPt(1),
 				Lagging:  testInt32ToPt(0),
 				Missing:  testInt32ToPt(9),
-				Outdated: testInt32ToPt(1),
+				Outdated: testInt32ToPt(0),
+			},
+		},
+		{
+			"2 paused deployments",
+			&konsumeratorv1alpha1.Consumer{
+				Spec: konsumeratorv1alpha1.ConsumerSpec{
+					NumPartitions: testInt32ToPt(10),
+					Autoscaler: &konsumeratorv1alpha1.AutoscalerSpec{
+						Mode:       "",
+						Prometheus: &konsumeratorv1alpha1.PrometheusAutoscalerSpec{},
+					},
+					DeploymentTemplate: appsv1.DeploymentSpec{},
+				},
+			},
+			appsv1.DeploymentList{
+				Items: []appsv1.Deployment{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								partitionAnnotation:         "6",
+								disableAutoscalerAnnotation: "true",
+							},
+						},
+						Status: appsv1.DeploymentStatus{Replicas: 1},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								partitionAnnotation:         "5",
+								disableAutoscalerAnnotation: "true",
+							},
+						},
+						Status: appsv1.DeploymentStatus{Replicas: 1},
+					},
+				},
+			},
+			konsumeratorv1alpha1.ConsumerStatus{
+				Expected: testInt32ToPt(10),
+				Running:  testInt32ToPt(0),
+				Paused:   testInt32ToPt(2),
+				Lagging:  testInt32ToPt(0),
+				Missing:  testInt32ToPt(8),
+				Outdated: testInt32ToPt(0),
 			},
 		},
 	}


### PR DESCRIPTION
Any deployment could have it's auto-scaling disabled by setting the annotation 
```
annotations:
    konsumerator.lwolf.org/disable-autoscaler: "true"
```
however currently it's not changing the scaling status, so deployment could have it's annotation in a confusing state, like:
```
  - apiVersion: konsumerator.lwolf.org/v1alpha1
    konsumerator.lwolf.org/disable-autoscaler: "true"
    konsumerator.lwolf.org/generation: "1492838215817756466"
    konsumerator.lwolf.org/partition: "1"
    konsumerator.lwolf.org/scaling-status: PENDING_SCALE_DOWN
    konsumerator.lwolf.org/scaling-status-change: 2019-09-13T12:18:05+01:00
```


maybe it makes sense to introduce one more status value to `konsumerator.lwolf.org/scaling-status` in addition to the following:
```
	InstanceStatusRunning          string = "RUNNING"
	InstanceStatusSaturated        string = "SATURATED"
	InstanceStatusPendingScaleUp   string = "PENDING_SCALE_UP"
	InstanceStatusPendingScaleDown string = "PENDING_SCALE_DOWN"
```
something like `MANUAL` 