### PR TITLE
manage pods in unknown state

### DIFF
--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -61,6 +61,10 @@ type ConfigMapReconciler struct {
 	Recorder record.EventRecorder
 	Scheme   *runtime.Scheme
 	Clock    clock.Clock
+
+	DeleteUnknownPods  bool
+	DeletePodFrequency int
+	DeletePodDeadline  time.Duration
 }
 
 func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -139,11 +143,14 @@ func (r *ConfigMapReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	o := &operator{
-		Recorder: r.Recorder,
-		clock:    r.Clock,
-		log:      log,
-		Scheme:   r.Scheme,
-		owner:    cm,
+		Recorder:           r.Recorder,
+		clock:              r.Clock,
+		log:                log,
+		Scheme:             r.Scheme,
+		owner:              cm,
+		deleteUnknownPods:  r.DeleteUnknownPods,
+		deletePodFrequency: r.DeletePodFrequency,
+		deletePodDeadline:  r.DeletePodDeadline,
 	}
 	PopulateStatusFromAnnotation(cm.Annotations, &consumer.Status)
 	initialStatus := consumer.Status.DeepCopy()

--- a/controllers/consumer.go
+++ b/controllers/consumer.go
@@ -54,6 +54,10 @@ type ConsumerReconciler struct {
 	Recorder record.EventRecorder
 	Scheme   *runtime.Scheme
 	Clock    clock.Clock
+
+	DeleteUnknownPods  bool
+	DeletePodFrequency int
+	DeletePodDeadline  time.Duration
 }
 
 func (r *ConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -116,11 +120,14 @@ func (r *ConsumerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	o := &operator{
-		Recorder: r.Recorder,
-		clock:    r.Clock,
-		log:      log,
-		Scheme:   r.Scheme,
-		owner:    &consumer,
+		Recorder:           r.Recorder,
+		clock:              r.Clock,
+		log:                log,
+		Scheme:             r.Scheme,
+		owner:              &consumer,
+		deleteUnknownPods:  r.DeleteUnknownPods,
+		deletePodFrequency: r.DeletePodFrequency,
+		deletePodDeadline:  r.DeletePodDeadline,
 	}
 	err := o.init(consumer.DeepCopy(), managedDeploys)
 	if err != nil {

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -17,6 +17,7 @@ const (
 	CPUSaturationLevel            = "konsumerator.lwolf.org/cpu-saturation-level"
 	ScalingStatusAnnotation       = "konsumerator.lwolf.org/scaling-status"
 	ScalingStatusChangeAnnotation = "konsumerator.lwolf.org/scaling-status-change"
+	KonsumeratorManagerAnnotation = "konsumerator.lwolf.org/managed"
 )
 
 var apiGVStr = konsumeratorv1alpha1.GroupVersion.String()

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -17,7 +17,7 @@ const (
 	CPUSaturationLevel            = "konsumerator.lwolf.org/cpu-saturation-level"
 	ScalingStatusAnnotation       = "konsumerator.lwolf.org/scaling-status"
 	ScalingStatusChangeAnnotation = "konsumerator.lwolf.org/scaling-status-change"
-	KonsumeratorManagerAnnotation = "konsumerator.lwolf.org/managed"
+	ManagedByLabel                = "konsumerator.lwolf.org/managed-by"
 )
 
 var apiGVStr = konsumeratorv1alpha1.GroupVersion.String()

--- a/controllers/reconcile_fake_test.go
+++ b/controllers/reconcile_fake_test.go
@@ -50,6 +50,9 @@ func initReconciler(consumer *konsumeratorv1alpha1.Consumer) (client.Client, *co
 		recorder,
 		s,
 		fakeClock,
+		true,
+		1,
+		time.Minute,
 	}
 }
 


### PR DESCRIPTION
This PR adds an additonal func on `operator` that is called
`managePodHealth` which helps to look at the status of the pod from
the pod template spec. If the satus is `PodUnknown`, then delete
action is called on the pod.

This new functionality is added to the reconcile logic loop
and the operator reconciles and kills pods that are stuck in
a unknown states every reconciliation loop.