### PR TITLE
Fix multi-partition resource estimation

### DIFF
--- a/pkg/predictors/naive.go
+++ b/pkg/predictors/naive.go
@@ -50,7 +50,7 @@ func (s *NaivePredictor) estimateMemory(consumption int64, ramPerCore int64, cpu
 func (s *NaivePredictor) Estimate(containerName string, partitions []int32) *corev1.ResourceRequirements {
 	var expectedConsumption int64
 	for _, p := range partitions {
-		expectedConsumption = s.expectedConsumption(p)
+		expectedConsumption += s.expectedConsumption(p)
 	}
 	cpuReq, cpuLimit := s.estimateCpu(expectedConsumption, *s.promSpec.RatePerCore)
 	memoryReq, memoryLimit := s.estimateMemory(expectedConsumption, s.promSpec.RamPerCore.MilliValue(), cpuReq, cpuLimit)

--- a/pkg/predictors/naive_test.go
+++ b/pkg/predictors/naive_test.go
@@ -170,6 +170,22 @@ func TestEstimateResources(t *testing.T) {
 				},
 			},
 		},
+		"base estimation (multiple partitions)": {
+			containerName: "test",
+			promSpec:      *genPromSpec(10000, resource.MustParse("1G")),
+			lagStore:      NewMockProvider(map[int32]int64{0: 20000, 1: 20000}, map[int32]int64{0: 20001, 1: 20001}, map[int32]int64{0: 0}),
+			partitions:    []int32{0,1},
+			expectedResources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("4G"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("4G"),
+				},
+			},
+		},
 		"low production rate": {
 			containerName: "test",
 			promSpec:      *genPromSpec(10000, resource.MustParse("1G")),


### PR DESCRIPTION
Multi-partition resource estimation has a bug where instead of
calculating expected consumption for all the partitions assigned
to the consumer it just uses the last one. Fix this.