### PR TITLE
Assign additional environment variables to deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@
 **Konsumerator** is a Kubernetes operator intended to automate management and resource allocations for 
 kafka consumers. 
 
-> This software is in active development phase, any logic and CRD structure could change between versions.
-> Use on your own risk. 
-
 Operator creates and manages `Consumer` CRD, for this it requires cluster-wide permissions.
 
 ```yaml
@@ -20,6 +17,7 @@ metadata:
   name: consumer-sample
 spec:
   numPartitions: 100
+  numPartitionsPerInstance: 1
   name: "test-consumer"
   namespace: "default"
   autoscaler:
@@ -125,9 +123,12 @@ It does not make sense to set resource field, since it will be overridden by aut
 * Deployment will be named `{consumerName}-{index}` where consumerName is `.spec.name` and index is in range
 from 0 to `.spec.numPartitions`. 
 * Resource requests/limits for each deployment will be estimated based on metrics and configuration
-* Each container in the deployment will get few environment variables set: `KONSUMERATOR_PARTITION` `GOMAXPROCS`.
-First one contains kafka partition number assigned to this deployment. Name of this variable is configurable.
-Second is golang specific setting, always equals to the `resources.limit.cpu`.
+* Each container in the deployment will get few environment variables set:
+    `KONSUMERATOR_PARTITION` - contains comma-separated list of kafka partition numbers assigned to this deployment. Name of this variable is configurable. 
+    `KONSUMERATOR_NUM_PARTITIONS` - total number of kafka partitions 
+    `KONSUMERATOR_INSTANCE` - ordinal of the instance 
+    `KONSUMERATOR_NUM_INSTANCES` - total number of instances 
+    `GOMAXPROCS` - golang specific setting, always equals to the `resources.limit.cpu`. 
 
 ## Metrics Providers
 

--- a/controllers/operator.go
+++ b/controllers/operator.go
@@ -382,7 +382,15 @@ func (o *operator) estimateDeploy(deploy *appsv1.Deployment) (*appsv1.Deployment
 				if o.scalingUpAllowed(lastStateChange, currentState) {
 					o.updateScaleAnnotations(deploy, underProvision)
 					container.Resources = *resources
-					container.Env = helpers.PopulateEnv(container.Env, &container.Resources, o.consumer.Spec.PartitionEnvKey, partitions)
+					container.Env = helpers.PopulateEnv(
+						container.Env,
+						&container.Resources,
+						o.consumer.Spec.PartitionEnvKey,
+						partitions,
+						int(consumerId),
+						int(*o.consumer.Spec.NumPartitions),
+						len(o.assignments),
+					)
 					needsUpdate = true
 				} else if currentState == InstanceStatusSaturated {
 					isChangedAnnotations = o.updateScaleAnnotations(deploy, underProvision)
@@ -397,7 +405,15 @@ func (o *operator) estimateDeploy(deploy *appsv1.Deployment) (*appsv1.Deployment
 				if o.scalingDownAllowed(lastStateChange, currentState) {
 					o.updateScaleAnnotations(deploy, underProvision)
 					container.Resources = *resources
-					container.Env = helpers.PopulateEnv(container.Env, &container.Resources, o.consumer.Spec.PartitionEnvKey, partitions)
+					container.Env = helpers.PopulateEnv(
+						container.Env,
+						&container.Resources,
+						o.consumer.Spec.PartitionEnvKey,
+						partitions,
+						int(consumerId),
+						int(*o.consumer.Spec.NumPartitions),
+						len(o.assignments),
+					)
 					needsUpdate = true
 				} else {
 					isChangedAnnotations = o.updateScalingStatus(deploy, InstanceStatusPendingScaleDown)
@@ -444,7 +460,15 @@ func (o *operator) updateDeploy(deploy *appsv1.Deployment) (*appsv1.Deployment, 
 		}
 		o.updateScaleAnnotations(deploy, underProvision)
 		container.Resources = *resources
-		container.Env = helpers.PopulateEnv(container.Env, &container.Resources, o.consumer.Spec.PartitionEnvKey, partitions)
+		container.Env = helpers.PopulateEnv(
+			container.Env,
+			&container.Resources,
+			o.consumer.Spec.PartitionEnvKey,
+			partitions,
+			int(consumerId),
+			int(*o.consumer.Spec.NumPartitions),
+			len(o.assignments),
+		)
 	}
 	return deploy, nil
 }

--- a/controllers/reconcile_fake_test.go
+++ b/controllers/reconcile_fake_test.go
@@ -134,9 +134,12 @@ func TestConsumerReconciliation(t *testing.T) {
 			},
 			expContainerEnv: map[string]map[string]string{
 				"busybox": {
-					"KONSUMERATOR_PARTITION": "0",
-					"GOMAXPROCS":             "1",
-					"testKey":                "testValue",
+					"KONSUMERATOR_PARTITION":      "0",
+					"GOMAXPROCS":                  "1",
+					"KONSUMERATOR_INSTANCE":       "0",
+					"KONSUMERATOR_NUM_INSTANCES":  "1",
+					"KONSUMERATOR_NUM_PARTITIONS": "1",
+					"testKey":                     "testValue",
 				},
 			},
 			expContainerResources: map[string]corev1.ResourceRequirements{
@@ -179,11 +182,17 @@ func TestConsumerReconciliation(t *testing.T) {
 				"busybox": {
 					"KONSUMERATOR_PARTITION": "0",
 					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_INSTANCE":       "0",
+					"KONSUMERATOR_NUM_INSTANCES":  "1",
+					"KONSUMERATOR_NUM_PARTITIONS": "1",
 					"TESTKEY":                "TESTVALUE",
 				},
 				"sidecar": {
 					"KONSUMERATOR_PARTITION": "0",
 					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_INSTANCE":       "0",
+					"KONSUMERATOR_NUM_INSTANCES":  "1",
+					"KONSUMERATOR_NUM_PARTITIONS": "1",
 					"SIDECAR_KEY":            "SIDECAR_VALUE",
 				},
 			},
@@ -236,11 +245,17 @@ func TestConsumerReconciliation(t *testing.T) {
 				"busybox": {
 					"KONSUMERATOR_PARTITION": "0",
 					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_INSTANCE":       "0",
+					"KONSUMERATOR_NUM_INSTANCES":  "1",
+					"KONSUMERATOR_NUM_PARTITIONS": "1",
 					"TESTKEY":                "TESTVALUE",
 				},
 				"sidecar": {
 					"KONSUMERATOR_PARTITION": "0",
 					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_INSTANCE":       "0",
+					"KONSUMERATOR_NUM_INSTANCES":  "1",
+					"KONSUMERATOR_NUM_PARTITIONS": "1",
 					"SIDECAR_KEY":            "SIDECAR_VALUE",
 				},
 			},
@@ -297,11 +312,17 @@ func TestConsumerReconciliation(t *testing.T) {
 				"busybox": {
 					"KONSUMERATOR_PARTITION": "0",
 					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_INSTANCE":       "0",
+					"KONSUMERATOR_NUM_INSTANCES":  "1",
+					"KONSUMERATOR_NUM_PARTITIONS": "1",
 					"TESTKEY":                "TESTVALUE",
 				},
 				"sidecar": {
 					"KONSUMERATOR_PARTITION": "0",
 					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_INSTANCE":       "0",
+					"KONSUMERATOR_NUM_INSTANCES":  "1",
+					"KONSUMERATOR_NUM_PARTITIONS": "1",
 					"SIDECAR_KEY":            "SIDECAR_VALUE",
 				},
 			},
@@ -371,7 +392,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 		{
 			name:                "should have one missing deployment on consumer creation",
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
-			expContainerEnv:     containerEnv("busybox", "0", "1"),
+			expContainerEnv:     containerEnv("busybox", "0", "1", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("100m", "100M", "100m", "100M"),
 			},
@@ -393,7 +414,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 10,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
-			expContainerEnv:     containerEnv("busybox", "0", "1"),
+			expContainerEnv:     containerEnv("busybox", "0", "1", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("100m", "100M", "100m", "100M"),
 			},
@@ -416,7 +437,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusPendingScaleUp),
-			expContainerEnv:     containerEnv("busybox", "0", "1"),
+			expContainerEnv:     containerEnv("busybox", "0", "1", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("100m", "100M", "100m", "100M"),
 			},
@@ -439,7 +460,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("1300m", "260M", "2", "260M"),
 			},
@@ -462,7 +483,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusPendingScaleUp),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("1300m", "260M", "2", "260M"),
 			},
@@ -485,7 +506,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotationSaturated(name, "400"),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("2", "480M", "2", "480M"),
 			},
@@ -508,7 +529,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotationSaturated(name, "200"),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("2", "480M", "2", "480M"),
 			},
@@ -531,7 +552,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusPendingScaleDown),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("2", "480M", "2", "480M"),
 			},
@@ -554,7 +575,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("1100m", "220M", "2", "220M"),
 			},
@@ -577,7 +598,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("1100m", "220M", "2", "220M"),
 			},
@@ -600,7 +621,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 1e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusPendingScaleDown),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("1100m", "220M", "2", "220M"),
 			},
@@ -623,7 +644,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("1100m", "220M", "2", "220M"),
 			},
@@ -646,7 +667,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("1.1", "220M", "2", "220M"),
 			},
@@ -669,7 +690,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusPendingScaleDown),
-			expContainerEnv:     containerEnv("busybox", "0", "2"),
+			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("1.1", "220M", "2", "220M"),
 			},
@@ -692,7 +713,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 				consumption: 5e3,
 			},
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
-			expContainerEnv:     containerEnv("busybox", "0", "1"),
+			expContainerEnv:     containerEnv("busybox", "0", "1", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
 				"busybox": *tests.NewResourceRequirements("100m", "100M", "1", "100M"),
 			},
@@ -989,10 +1010,13 @@ type fakeMetrics struct {
 	consumption int64
 }
 
-func containerEnv(name, partition, gomaxprocs string) map[string]map[string]string {
+func containerEnv(name, partition, gomaxprocs, instance, numP, numI string) map[string]map[string]string {
 	return map[string]map[string]string{
 		name: {
 			"KONSUMERATOR_PARTITION": partition,
+			"KONSUMERATOR_INSTANCE": instance,
+			"KONSUMERATOR_NUM_INSTANCES": numI,
+			"KONSUMERATOR_NUM_PARTITIONS": numP,
 			"GOMAXPROCS":             gomaxprocs,
 		},
 	}

--- a/pkg/helpers/util.go
+++ b/pkg/helpers/util.go
@@ -13,6 +13,9 @@ import (
 
 const (
 	defaultPartitionEnvKey = "KONSUMERATOR_PARTITION"
+	instanceEnvKey         = "KONSUMERATOR_INSTANCE"
+	numInstancesEnvKey     = "KONSUMERATOR_NUM_INSTANCES"
+	numPartitionsEnvKey    = "KONSUMERATOR_NUM_PARTITIONS"
 	gomaxprocsEnvKey       = "GOMAXPROCS"
 	TimeLayout             = time.RFC3339
 )
@@ -88,7 +91,7 @@ func SetEnv(env []corev1.EnvVar, key string, value string) []corev1.EnvVar {
 	return env
 }
 
-func PopulateEnv(currentEnv []corev1.EnvVar, resources *corev1.ResourceRequirements, envKey string, partitions []int32) []corev1.EnvVar {
+func PopulateEnv(currentEnv []corev1.EnvVar, resources *corev1.ResourceRequirements, envKey string, partitions []int32, id, numPartitions, numInstances int) []corev1.EnvVar {
 	var partitionKey string
 	if envKey != "" {
 		partitionKey = envKey
@@ -99,6 +102,9 @@ func PopulateEnv(currentEnv []corev1.EnvVar, resources *corev1.ResourceRequireme
 	copy(env, currentEnv)
 	env = SetEnv(env, partitionKey, strings.Join(Int2Str(partitions), ","))
 	env = SetEnv(env, gomaxprocsEnvKey, GomaxprocsFromResource(resources.Limits.Cpu()))
+	env = SetEnv(env, instanceEnvKey, strconv.Itoa(id))
+	env = SetEnv(env, numPartitionsEnvKey, strconv.Itoa(numPartitions))
+	env = SetEnv(env, numInstancesEnvKey, strconv.Itoa(numInstances))
 
 	return env
 }

--- a/pkg/helpers/util_test.go
+++ b/pkg/helpers/util_test.go
@@ -10,11 +10,14 @@ import (
 
 func TestPopulateEnv(t *testing.T) {
 	tests := map[string]struct {
-		initialEnv []corev1.EnvVar
-		resources  *corev1.ResourceRequirements
-		envKey     string
-		partitions []int32
-		expEnv     []corev1.EnvVar
+		initialEnv    []corev1.EnvVar
+		resources     *corev1.ResourceRequirements
+		envKey        string
+		partitions    []int32
+		instanceId    int
+		numPartitions int
+		numInstances  int
+		expEnv        []corev1.EnvVar
 	}{
 		"simple case": {
 			initialEnv: nil,
@@ -28,15 +31,31 @@ func TestPopulateEnv(t *testing.T) {
 					corev1.ResourceMemory: resource.MustParse("2G"),
 				},
 			},
-			envKey:     "",
-			partitions: []int32{0},
+			envKey:        "",
+			partitions:    []int32{0},
+			instanceId:    0,
+			numPartitions: 1,
+			numInstances:  1,
 			expEnv: []corev1.EnvVar{
 				{
 					Name:  defaultPartitionEnvKey,
 					Value: "0",
-				}, {
+				},
+				{
 					Name:  gomaxprocsEnvKey,
 					Value: "2",
+				},
+				{
+					Name:  instanceEnvKey,
+					Value: "0",
+				},
+				{
+					Name:  numPartitionsEnvKey,
+					Value: "1",
+				},
+				{
+					Name:  numInstancesEnvKey,
+					Value: "1",
 				},
 			},
 		},
@@ -52,14 +71,30 @@ func TestPopulateEnv(t *testing.T) {
 					corev1.ResourceMemory: resource.MustParse("2G"),
 				},
 			},
-			envKey:     "TEST_PARTITION",
-			partitions: []int32{0},
+			envKey:        "TEST_PARTITION",
+			partitions:    []int32{0},
+			instanceId:    0,
+			numPartitions: 1,
+			numInstances:  1,
 			expEnv: []corev1.EnvVar{
 				{
 					Name:  "TEST_PARTITION",
 					Value: "0",
-				}, {
+				},
+				{
 					Name:  gomaxprocsEnvKey,
+					Value: "1",
+				},
+				{
+					Name:  instanceEnvKey,
+					Value: "0",
+				},
+				{
+					Name:  numPartitionsEnvKey,
+					Value: "1",
+				},
+				{
+					Name:  numInstancesEnvKey,
 					Value: "1",
 				},
 			},
@@ -68,7 +103,7 @@ func TestPopulateEnv(t *testing.T) {
 	for testName, tt := range tests {
 		t.Run(testName, func(t *testing.T) {
 			backupEnv := append(tt.initialEnv[:0:0], tt.initialEnv...) // backup original env
-			got := PopulateEnv(tt.initialEnv, tt.resources, tt.envKey, tt.partitions)
+			got := PopulateEnv(tt.initialEnv, tt.resources, tt.envKey, tt.partitions, tt.instanceId, tt.numPartitions, tt.numInstances)
 			if diff := cmp.Diff(tt.expEnv, got); diff != "" {
 				t.Errorf("%s PopulateEnv() mismatch (-tt.expEnv +got):\n%s", testName, diff)
 			}


### PR DESCRIPTION
Konsumerator now assignes several additional env variables
to each deployment:
  `KONSUMERATOR_NUM_PARTITIONS` - total number of kafka partitions
  `KONSUMERATOR_INSTANCE` - ordinal of the instance
  `KONSUMERATOR_NUM_INSTANCES` - total number of instances