### PR TITLE
Tie memory estimations to CPU limits instead of requests

### DIFF
--- a/controllers/reconcile_fake_test.go
+++ b/controllers/reconcile_fake_test.go
@@ -462,7 +462,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("1300m", "260M", "2", "260M"),
+				"busybox": *tests.NewResourceRequirements("1300m", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -485,7 +485,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusPendingScaleUp),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("1300m", "260M", "2", "260M"),
+				"busybox": *tests.NewResourceRequirements("1300m", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -508,7 +508,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotationSaturated(name, "400"),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("2", "480M", "2", "480M"),
+				"busybox": *tests.NewResourceRequirements("2", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -531,7 +531,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotationSaturated(name, "200"),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("2", "480M", "2", "480M"),
+				"busybox": *tests.NewResourceRequirements("2", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -554,7 +554,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusPendingScaleDown),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("2", "480M", "2", "480M"),
+				"busybox": *tests.NewResourceRequirements("2", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -577,7 +577,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("1100m", "220M", "2", "220M"),
+				"busybox": *tests.NewResourceRequirements("1100m", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -600,7 +600,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("1100m", "220M", "2", "220M"),
+				"busybox": *tests.NewResourceRequirements("1100m", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -623,7 +623,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusPendingScaleDown),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("1100m", "220M", "2", "220M"),
+				"busybox": *tests.NewResourceRequirements("1100m", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -646,7 +646,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("1100m", "220M", "2", "220M"),
+				"busybox": *tests.NewResourceRequirements("1100m", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -669,7 +669,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("1.1", "220M", "2", "220M"),
+				"busybox": *tests.NewResourceRequirements("1.1", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -692,7 +692,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusPendingScaleDown),
 			expContainerEnv:     containerEnv("busybox", "0", "2", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("1.1", "220M", "2", "220M"),
+				"busybox": *tests.NewResourceRequirements("1.1", "400M", "2", "400M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -715,7 +715,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 			expDeployAnnotation: deployAnnotation(name, controllers.InstanceStatusRunning),
 			expContainerEnv:     containerEnv("busybox", "0", "1", "0", "1", "1"),
 			expContainerResources: map[string]corev1.ResourceRequirements{
-				"busybox": *tests.NewResourceRequirements("100m", "100M", "1", "100M"),
+				"busybox": *tests.NewResourceRequirements("100m", "200M", "1", "200M"),
 			},
 			expConsumerState: konsumeratorv1alpha1.ConsumerStatus{
 				Expected:  helpers.Ptr2Int32(1),
@@ -740,7 +740,7 @@ func TestConsumerReconciler_Reconcile(t *testing.T) {
 	}
 	c.Spec.ResourcePolicy = &konsumeratorv1alpha1.ResourcePolicy{
 		ContainerPolicies: []konsumeratorv1alpha1.ContainerResourcePolicy{
-			tests.NewContainerResourcePolicy("busybox", "100m", "100M", "2", "1.6G"),
+			tests.NewContainerResourcePolicy("busybox", "100m", "100M", "2", "400M"),
 		},
 	}
 	c.Spec.Autoscaler.Prometheus.Address = []string{promServer.URL}

--- a/pkg/predictors/naive.go
+++ b/pkg/predictors/naive.go
@@ -41,10 +41,9 @@ func (s *NaivePredictor) estimateCpu(consumption int64, ratePerCore int64) (int6
 	cpuReq := math.Ceil(float64(consumption)/float64(ratePerCore)*10) / 10
 	return int64(cpuReq * 1000), int64(math.Ceil(cpuReq)) * 1000
 }
-func (s *NaivePredictor) estimateMemory(consumption int64, ramPerCore int64, cpuR int64, cpuL int64) (int64, int64) {
-	requests := cpuR * (ramPerCore / 1000)
+func (s *NaivePredictor) estimateMemory(ramPerCore int64, cpuL int64) (int64, int64) {
 	limit := cpuL * (ramPerCore / 1000)
-	return requests, limit
+	return limit, limit
 }
 
 func (s *NaivePredictor) Estimate(containerName string, partitions []int32) *corev1.ResourceRequirements {
@@ -53,7 +52,7 @@ func (s *NaivePredictor) Estimate(containerName string, partitions []int32) *cor
 		expectedConsumption += s.expectedConsumption(p)
 	}
 	cpuReq, cpuLimit := s.estimateCpu(expectedConsumption, *s.promSpec.RatePerCore)
-	memoryReq, memoryLimit := s.estimateMemory(expectedConsumption, s.promSpec.RamPerCore.MilliValue(), cpuReq, cpuLimit)
+	memoryReq, memoryLimit := s.estimateMemory(s.promSpec.RamPerCore.MilliValue(), cpuLimit)
 	s.log.V(1).Info(
 		"resource estimation results",
 		"containerName", containerName,


### PR DESCRIPTION
Most of concurrency settings in the consumers are based on
GOMAXPROCS, which are based on CPU limits. When we use memory
autoscaling, we should do the same, otherwise we're underestimate
memory and get OOM.