### PR TITLE
Fix deployment status values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ vet:
 
 # Generate code
 generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt,year=2019 paths=./api/...
+	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt,year=2020 paths=./api/...
 
 # Build the docker image
 docker-build: build test

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -124,7 +124,7 @@ var (
 			Subsystem: "deployment",
 			Name:      "status",
 			Help: "Current deployment status. " +
-				"0 - RUNNING, 1 - SATURATED, 2 - PENDING_SCALE_UP, 3 - PENDING_SCALE_DOWN, -1 - UNKNOWN",
+				"1 - RUNNING, 2 - SATURATED, 3 - PENDING_SCALE_UP, 4 - PENDING_SCALE_DOWN, 0 - UNKNOWN",
 		},
 		[]string{"consumer", "deployment"},
 	)

--- a/controllers/reconcile_fake_test.go
+++ b/controllers/reconcile_fake_test.go
@@ -180,20 +180,20 @@ func TestConsumerReconciliation(t *testing.T) {
 			},
 			expContainerEnv: map[string]map[string]string{
 				"busybox": {
-					"KONSUMERATOR_PARTITION": "0",
-					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_PARTITION":      "0",
+					"GOMAXPROCS":                  "1",
 					"KONSUMERATOR_INSTANCE":       "0",
 					"KONSUMERATOR_NUM_INSTANCES":  "1",
 					"KONSUMERATOR_NUM_PARTITIONS": "1",
-					"TESTKEY":                "TESTVALUE",
+					"TESTKEY":                     "TESTVALUE",
 				},
 				"sidecar": {
-					"KONSUMERATOR_PARTITION": "0",
-					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_PARTITION":      "0",
+					"GOMAXPROCS":                  "1",
 					"KONSUMERATOR_INSTANCE":       "0",
 					"KONSUMERATOR_NUM_INSTANCES":  "1",
 					"KONSUMERATOR_NUM_PARTITIONS": "1",
-					"SIDECAR_KEY":            "SIDECAR_VALUE",
+					"SIDECAR_KEY":                 "SIDECAR_VALUE",
 				},
 			},
 			expContainerResources: map[string]corev1.ResourceRequirements{
@@ -243,20 +243,20 @@ func TestConsumerReconciliation(t *testing.T) {
 			},
 			expContainerEnv: map[string]map[string]string{
 				"busybox": {
-					"KONSUMERATOR_PARTITION": "0",
-					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_PARTITION":      "0",
+					"GOMAXPROCS":                  "1",
 					"KONSUMERATOR_INSTANCE":       "0",
 					"KONSUMERATOR_NUM_INSTANCES":  "1",
 					"KONSUMERATOR_NUM_PARTITIONS": "1",
-					"TESTKEY":                "TESTVALUE",
+					"TESTKEY":                     "TESTVALUE",
 				},
 				"sidecar": {
-					"KONSUMERATOR_PARTITION": "0",
-					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_PARTITION":      "0",
+					"GOMAXPROCS":                  "1",
 					"KONSUMERATOR_INSTANCE":       "0",
 					"KONSUMERATOR_NUM_INSTANCES":  "1",
 					"KONSUMERATOR_NUM_PARTITIONS": "1",
-					"SIDECAR_KEY":            "SIDECAR_VALUE",
+					"SIDECAR_KEY":                 "SIDECAR_VALUE",
 				},
 			},
 			expContainerResources: map[string]corev1.ResourceRequirements{
@@ -310,20 +310,20 @@ func TestConsumerReconciliation(t *testing.T) {
 			},
 			expContainerEnv: map[string]map[string]string{
 				"busybox": {
-					"KONSUMERATOR_PARTITION": "0",
-					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_PARTITION":      "0",
+					"GOMAXPROCS":                  "1",
 					"KONSUMERATOR_INSTANCE":       "0",
 					"KONSUMERATOR_NUM_INSTANCES":  "1",
 					"KONSUMERATOR_NUM_PARTITIONS": "1",
-					"TESTKEY":                "TESTVALUE",
+					"TESTKEY":                     "TESTVALUE",
 				},
 				"sidecar": {
-					"KONSUMERATOR_PARTITION": "0",
-					"GOMAXPROCS":             "1",
+					"KONSUMERATOR_PARTITION":      "0",
+					"GOMAXPROCS":                  "1",
 					"KONSUMERATOR_INSTANCE":       "0",
 					"KONSUMERATOR_NUM_INSTANCES":  "1",
 					"KONSUMERATOR_NUM_PARTITIONS": "1",
-					"SIDECAR_KEY":            "SIDECAR_VALUE",
+					"SIDECAR_KEY":                 "SIDECAR_VALUE",
 				},
 			},
 			expContainerResources: map[string]corev1.ResourceRequirements{
@@ -1013,11 +1013,11 @@ type fakeMetrics struct {
 func containerEnv(name, partition, gomaxprocs, instance, numP, numI string) map[string]map[string]string {
 	return map[string]map[string]string{
 		name: {
-			"KONSUMERATOR_PARTITION": partition,
-			"KONSUMERATOR_INSTANCE": instance,
-			"KONSUMERATOR_NUM_INSTANCES": numI,
+			"KONSUMERATOR_PARTITION":      partition,
+			"KONSUMERATOR_INSTANCE":       instance,
+			"KONSUMERATOR_NUM_INSTANCES":  numI,
 			"KONSUMERATOR_NUM_PARTITIONS": numP,
-			"GOMAXPROCS":             gomaxprocs,
+			"GOMAXPROCS":                  gomaxprocs,
 		},
 	}
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -68,15 +68,15 @@ func resourceListDiff(a, b corev1.ResourceList) corev1.ResourceList {
 func instanceStatusToInt(status string) int {
 	switch status {
 	case InstanceStatusRunning:
-		return 0
-	case InstanceStatusSaturated:
 		return 1
-	case InstanceStatusPendingScaleUp:
+	case InstanceStatusSaturated:
 		return 2
-	case InstanceStatusPendingScaleDown:
+	case InstanceStatusPendingScaleUp:
 		return 3
+	case InstanceStatusPendingScaleDown:
+		return 4
 	default:
-		return -1
+		return 0
 	}
 }
 

--- a/pkg/predictors/naive_test.go
+++ b/pkg/predictors/naive_test.go
@@ -182,7 +182,7 @@ func TestEstimateResources(t *testing.T) {
 			containerName: "test",
 			promSpec:      *genPromSpec(10000, resource.MustParse("1G")),
 			lagStore:      NewMockProvider(map[int32]int64{0: 20000, 1: 20000}, map[int32]int64{0: 20001, 1: 20001}, map[int32]int64{0: 0}),
-			partitions:    []int32{0,1},
+			partitions:    []int32{0, 1},
 			expectedResources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),


### PR DESCRIPTION
When deployment is being deleted, deployment status metric continue
be exist in Prometheus with the value of 0. Which with current design
results in messed up graphs. Effectively each time you change number of
pods you get N more `running` deployments in the dashboard.

This incompatible change fixes this.