### PR TITLE
Set deployment status to 0 on delete

### DIFF
--- a/controllers/operator.go
+++ b/controllers/operator.go
@@ -123,6 +123,7 @@ func (o *operator) reconcile(cl client.Client, req ctrl.Request) error {
 
 	var deleted int
 	for _, deploy := range o.toRemoveInstances {
+		deploymentStatus.WithLabelValues(o.consumer.Name, deploy.Name).Set(0)
 		if err := cl.Delete(ctx, deploy); errors.IgnoreNotFound(err) != nil {
 			o.log.Error(err, "unable to delete deployment", "deployment", deploy)
 			deploymentsDeleteErrors.WithLabelValues(req.Name).Inc()


### PR DESCRIPTION
Prometheus remembers the last value of the metric for some (long) time
after the metric dissapears, which results in incorrect data shown in
the dashboards. With this change, Prometheus should remember this value,
and as a result we can filter out these obsolete metrics.