### PR TITLE
Respect criticalLag during resource allocation

### DIFF
--- a/pkg/limiters/global_limiter.go
+++ b/pkg/limiters/global_limiter.go
@@ -48,6 +48,18 @@ func NewGlobalLimiter(policy *konsumeratorv1alpha1.ResourcePolicy, used *corev1.
 	return l
 }
 
+// nop
+func (l *GlobalLimiter) MinAllowed(_ string) *corev1.ResourceList {
+	return nil
+}
+
+func (l *GlobalLimiter) MaxAllowed(_ string) *corev1.ResourceList {
+	return &corev1.ResourceList{
+		corev1.ResourceCPU:    *resource.NewMilliQuantity(l.availCPU.MilliValue(), resource.DecimalSI),
+		corev1.ResourceMemory: *resource.NewMilliQuantity(l.availMem.MilliValue(), resource.DecimalSI),
+	}
+}
+
 func (l *GlobalLimiter) ApplyLimits(_ string, resources *corev1.ResourceRequirements) *corev1.ResourceRequirements {
 	if l.availMem == nil || l.availCPU == nil {
 		// no limits were applied - returning as is

--- a/pkg/limiters/global_limiter_test.go
+++ b/pkg/limiters/global_limiter_test.go
@@ -124,6 +124,10 @@ func TestGlobalLimiter_ApplyLimits2(t *testing.T) {
 		if helpers.CmpResourceList(*state, *step.expState) != 0 {
 			t.Fatalf("step %d - limiter state results mismatch. \nWant: \n%v; \nGot: \n%v", i+1, step.expState, r)
 		}
+		// verify that ".MaxAllowed()" returns the same amount of "free"  resources as expected
+		if helpers.CmpResourceList(*limiter.MaxAllowed(""), *step.expState) != 0 {
+			t.Fatalf("step %d - limiter state results mismatch. \nWant: \n%v; \nGot: \n%v", i+1, step.expState, r)
+		}
 	}
 }
 

--- a/pkg/limiters/instance_limiter.go
+++ b/pkg/limiters/instance_limiter.go
@@ -26,6 +26,22 @@ func NewInstanceLimiter(policy *konsumeratorv1alpha1.ResourcePolicy, log logr.Lo
 	}
 }
 
+func (il *InstanceLimiter) MinAllowed(containerName string) *corev1.ResourceList {
+	policy, ok := il.registry[containerName]
+	if !ok {
+		return nil
+	}
+	return &policy.MinAllowed
+}
+
+func (il *InstanceLimiter) MaxAllowed(containerName string) *corev1.ResourceList {
+	policy, ok := il.registry[containerName]
+	if !ok {
+		return nil
+	}
+	return &policy.MaxAllowed
+}
+
 func (il *InstanceLimiter) ApplyLimits(containerName string, resources *corev1.ResourceRequirements) *corev1.ResourceRequirements {
 	limits, ok := il.registry[containerName]
 	if !ok {

--- a/pkg/limiters/limiter.go
+++ b/pkg/limiters/limiter.go
@@ -5,5 +5,7 @@ import (
 )
 
 type ResourceLimiter interface {
+	MinAllowed(containerName string) *corev1.ResourceList
+	MaxAllowed(containerName string) *corev1.ResourceList
 	ApplyLimits(containerName string, resources *corev1.ResourceRequirements) *corev1.ResourceRequirements
 }


### PR DESCRIPTION
`.spec.autoscaler.prometheus.critical_lag` was never
implemented, apart from the configuratino option.

By initial design this value is supposed to serve as SLO,
which tells konsumerator to allocate maximum allowed
resources per consumer upon breach.

Implement the actual behaviour in the code.