### PR TITLE
Expose binary version as a metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-VERSION ?= $(shell git rev-list --count HEAD)-$(shell git rev-parse --short=7 HEAD)
+VERSION ?= $(shell git describe --tags --always --dirty="-dev")
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/lwolf/konsumerator:$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/config/samples/konsumerator_v1alpha1_consumer.yaml
+++ b/config/samples/konsumerator_v1alpha1_consumer.yaml
@@ -1,4 +1,4 @@
-apiVersion: konsumerator.lwolf.org/v1alpha1
+apiVersion: konsumerator.lwolf.org/v1
 kind: Consumer
 metadata:
   name: consumer-sample

--- a/hack/ci/consumer-test.yaml
+++ b/hack/ci/consumer-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: konsumerator.lwolf.org/v1alpha1
+apiVersion: konsumerator.lwolf.org/v1
 kind: Consumer
 metadata:
   name: consumer-sample


### PR DESCRIPTION
Change version string that is being set during compile tag
to include the last tag in it. This will make it easier to
track different versions (v1, v2).

Expose version as prometheus metric.