### PR TITLE
Truncate long label values

### DIFF
--- a/controllers/operator.go
+++ b/controllers/operator.go
@@ -499,9 +499,9 @@ func (o *operator) updateDeploy(deploy *appsv1.Deployment) (*appsv1.Deployment, 
 func (o *operator) constructDeploy(consumerId int32) *appsv1.Deployment {
 	partitionIds := o.assignments[consumerId]
 	deployLabels := map[string]string{
-		"app":        o.consumer.Spec.Name,
-		"controller": o.consumer.Name,
-		"partitions": strings.Join(helpers.Int2Str(partitionIds), "-"),
+		"app":        helpers.EnsureValidLabelValue(o.consumer.Spec.Name),
+		"controller": helpers.EnsureValidLabelValue(o.consumer.Name),
+		"partitions": helpers.EnsureValidLabelValue(helpers.ConsecutiveIntsToRange(partitionIds)),
 	}
 	deployAnnotations := make(map[string]string)
 	deploy := &appsv1.Deployment{

--- a/pkg/helpers/util.go
+++ b/pkg/helpers/util.go
@@ -9,6 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -185,4 +186,37 @@ func Int2Str(ints []int32) []string {
 		result[i] = strconv.Itoa(int(d))
 	}
 	return result
+}
+
+// ConsecutiveIntsToRange takes a list of sorted integers and returns
+// string representation of its range
+// ConsecutiveIntsToRange(0,1,2,3,4,5,6) -> 0-6
+// ConsecutiveIntsToRange(12,13,14,15,16) -> 12-16
+func ConsecutiveIntsToRange(ints []int32) string {
+	res := make([]int32, 2)
+	if len(ints) < 3 {
+		res = ints
+	} else {
+		res = []int32{ints[0], ints[len(ints)-1]}
+	}
+	return strings.Join(Int2Str(res), "-")
+}
+
+func EnsureValidLabelValue(s string) string {
+	/*
+		https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+		Valid label value:
+		* must be 63 characters or less (cannot be empty),
+		* must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+		* could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+
+		For now we only ensure the max length here
+		TODO: decide what to do with labels containing incompatible chars. At the moment having bad name will break in
+		many places, not only in labels.
+
+	*/
+	if len(s) > validation.LabelValueMaxLength {
+		return s[:validation.LabelValueMaxLength]
+	}
+	return s
 }

--- a/pkg/helpers/util_test.go
+++ b/pkg/helpers/util_test.go
@@ -303,3 +303,54 @@ func TestParsePartitionsListAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestConsecutiveIntsToRange(t *testing.T) {
+	testCases := map[string]struct {
+		in  []int32
+		exp string
+	}{
+		"single digits not a range": {
+			[]int32{0},
+			"0",
+		},
+		"double digit is a range": {
+			[]int32{0, 1},
+			"0-1",
+		},
+		"many digits making range": {
+			[]int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12},
+			"0-12",
+		},
+		"vary many digits still make range": {
+			[]int32{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29},
+			"2-29",
+		},
+	}
+	for testName, tc := range testCases {
+		if res := ConsecutiveIntsToRange(tc.in); res != tc.exp {
+			t.Fatalf("%s: expected to get `%s`, got `%s`", testName, tc.exp, res)
+		}
+	}
+
+}
+
+func TestEnsureValidLabelValue(t *testing.T) {
+	testCases := map[string]struct {
+		in  string
+		exp string
+	}{
+		"short label value is OK": {
+			"0-1-2-3-4-5-6-7-8-10-12",
+			"0-1-2-3-4-5-6-7-8-10-12",
+		},
+		"long name should be cut up to the limit": {
+			"0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18-19-20-21-22-23-24-25-26-27-28-29",
+			"0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18-19-20-21-22-23-2",
+		},
+	}
+	for testName, tc := range testCases {
+		if res := EnsureValidLabelValue(tc.in); res != tc.exp {
+			t.Fatalf("%s: expected to get `%s`, got `%s`", testName, tc.exp, res)
+		}
+	}
+}


### PR DESCRIPTION
Label values are limited to 63 characters in K8s. Make sure
that when we create new Deployments/Pods we conform to the limits.