### PR TITLE
Fix bug in global limiter

### DIFF
--- a/controllers/operator.go
+++ b/controllers/operator.go
@@ -569,16 +569,10 @@ func (o *operator) updateResources(container *corev1.Container, partitions []int
 	currentResources := container.Resources.DeepCopy()
 
 	request := resourceRequirementsDiff(estimatedResources, currentResources)
-	requestedResources := o.globalLimiter.ApplyLimits("", request)
-	if requestedResources == nil {
-		// global limiter exhausted
-		// return existing resources
-		return &container.Resources, reqDiff
-	}
-
+	allowedResources := o.globalLimiter.ApplyLimits("", request)
 	// sum-up current and requested resources
-	limitedResources := resourceRequirementsSum(currentResources, requestedResources)
-	globalDiff := request.Requests.Cpu().MilliValue() - requestedResources.Requests.Cpu().MilliValue()
+	limitedResources := resourceRequirementsSum(currentResources, allowedResources)
+	globalDiff := request.Requests.Cpu().MilliValue() - allowedResources.Requests.Cpu().MilliValue()
 	return limitedResources, reqDiff + globalDiff
 }
 


### PR DESCRIPTION
GlobalLimiter returns false positive when only one of the resource pools is being exhausted. This leads to the instance not being scaled up when it's needed.

For example, when memory pool is empty (due to 1-1 allocation), instances will only be scaled up (cpu-wise) when some instance isn't running, otherwise it will be locked with amount of CPUs set to it during creation.