### PR TITLE
Allow configuring of a minimal scaling step (cpu)

### DIFF
--- a/api/v1/consumer_types.go
+++ b/api/v1/consumer_types.go
@@ -111,11 +111,15 @@ type PrometheusAutoscalerSpec struct {
 	Production  ProductionQuerySpec  `json:"production"`
 	Consumption ConsumptionQuerySpec `json:"consumption"`
 
-	RatePerCore  *int64            `json:"ratePerCore"`
-	RamPerCore   resource.Quantity `json:"ramPerCore"`
-	TolerableLag *metav1.Duration  `json:"tolerableLag"`
-	CriticalLag  *metav1.Duration  `json:"criticalLag"`
-	RecoveryTime *metav1.Duration  `json:"recoveryTime"`
+	RatePerCore *int64            `json:"ratePerCore"`
+	RamPerCore  resource.Quantity `json:"ramPerCore"`
+
+	// CpuIncrement sets the minimum cpu scaling step (default is 100m)
+	// +optional
+	CpuIncrement *resource.Quantity `json:"cpuIncrement,omitempty"`
+	TolerableLag *metav1.Duration   `json:"tolerableLag"`
+	CriticalLag  *metav1.Duration   `json:"criticalLag"`
+	RecoveryTime *metav1.Duration   `json:"recoveryTime"`
 }
 
 type OffsetQuerySpec struct {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -356,6 +356,11 @@ func (in *PrometheusAutoscalerSpec) DeepCopyInto(out *PrometheusAutoscalerSpec) 
 		**out = **in
 	}
 	out.RamPerCore = in.RamPerCore.DeepCopy()
+	if in.CpuIncrement != nil {
+		in, out := &in.CpuIncrement, &out.CpuIncrement
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	if in.TolerableLag != nil {
 		in, out := &in.TolerableLag, &out.TolerableLag
 		*out = new(metav1.Duration)

--- a/config/crd/bases/konsumerator.lwolf.org_consumers.yaml
+++ b/config/crd/bases/konsumerator.lwolf.org_consumers.yaml
@@ -88,6 +88,14 @@ spec:
                         - partitionLabel
                         - query
                         type: object
+                      cpuIncrement:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: CpuIncrement sets the minimum cpu scaling step
+                          (default is 100m)
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                       criticalLag:
                         type: string
                       minSyncPeriod:

--- a/pkg/predictors/naive_test.go
+++ b/pkg/predictors/naive_test.go
@@ -38,32 +38,57 @@ func TestEstimateCpu(t *testing.T) {
 	tests := map[string]struct {
 		consumption  int64
 		ratePerCore  int64
+		cpuIncrement int64
 		expectedCpuR int64
 		expectedCpuL int64
 	}{
 		"simple case": {
 			consumption:  20000,
 			ratePerCore:  10000,
+			cpuIncrement: 100,
 			expectedCpuR: 2000,
 			expectedCpuL: 2000,
 		},
 		"cpuLimit should be rounded to the CPU": {
 			consumption:  18000,
 			ratePerCore:  10000,
+			cpuIncrement: 100,
 			expectedCpuR: 1800,
 			expectedCpuL: 2000,
 		},
 		"cpuRequest should be rounded to 100 millicore": {
 			consumption:  18510,
 			ratePerCore:  10000,
+			cpuIncrement: 100,
 			expectedCpuR: 1900,
+			expectedCpuL: 2000,
+		},
+		"cpuRequest should be rounded to a custom value (400 mCPU)": {
+			consumption:  11510,
+			ratePerCore:  10000,
+			cpuIncrement: 400,
+			expectedCpuR: 1200,
+			expectedCpuL: 2000,
+		},
+		"cpuRequest should be rounded to a custom value (500 mCPU)": {
+			consumption:  11510,
+			ratePerCore:  10000,
+			cpuIncrement: 500,
+			expectedCpuR: 1500,
+			expectedCpuL: 2000,
+		},
+		"cpuRequest should be rounded to a custom value (1 CPU)": {
+			consumption:  11510,
+			ratePerCore:  10000,
+			cpuIncrement: 1000,
+			expectedCpuR: 2000,
 			expectedCpuL: 2000,
 		},
 	}
 	for testName, tt := range tests {
 		t.Run(testName, func(t *testing.T) {
 			estimator := NaivePredictor{log: testLogger()}
-			cpuR, cpuL := estimator.estimateCpu(tt.consumption, tt.ratePerCore)
+			cpuR, cpuL := estimator.estimateCpu(tt.consumption, tt.ratePerCore, tt.cpuIncrement)
 			if cpuR != tt.expectedCpuR {
 				t.Fatalf("expected Request CPU %d, got %d", tt.expectedCpuR, cpuR)
 			}

--- a/pkg/providers/prometheus.go
+++ b/pkg/providers/prometheus.go
@@ -46,7 +46,6 @@ var allConsFailedErr = errors.New("unable to reach any prometheus address")
 
 var once sync.Once
 
-// TODO: make spec passed by value
 func NewPrometheusMP(log logr.Logger, spec *konsumeratorv1.PrometheusAutoscalerSpec, consumer string) (*PrometheusMP, error) {
 	once.Do(initMetrics)
 


### PR DESCRIPTION
Historically konsumerator operated on 100m units for allocating the CPU. Every time any scaling decision is made, the value is rounded up to the next 100m. For some workloads (those that operate on 5-10-15 CPUs) it doesn't make sense to have such small granularity. Introduce a new, optional, `cpuIncrement` field in the manifest that will allow custom values.

	Co-authored-by: Constantin S. Pan <kvapen@gmail.com>