### PR TITLE
Rework estimate func / Extend action loagline

### DIFF
--- a/hack/ci/consumer-test-configmap.yaml
+++ b/hack/ci/consumer-test-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     konsumerator.lwolf.org/managed: "true"
 data:
   consumer.yaml: |
-    numPartitions: 10
+    numPartitions: 4
     name: "test-consumer"
     namespace: "konsumerator-system"
     autoscaler:

--- a/hack/ci/consumer-test.yaml
+++ b/hack/ci/consumer-test.yaml
@@ -3,8 +3,8 @@ kind: Consumer
 metadata:
   name: consumer-sample
 spec:
-  numPartitions: 2
-  numPartitionsPerInstance: 2
+  numPartitions: 4
+  numPartitionsPerInstance: 1
   name: "test-consumer"
   namespace: "konsumerator-system"
   autoscaler:

--- a/hack/faker/deploy/deploy.yaml
+++ b/hack/faker/deploy/deploy.yaml
@@ -28,8 +28,8 @@ spec:
           - producer
           - --redisAddr=redis:6379
           - --port=9000
-          - --num-partitions=10
-          - --base-rate=40000
+          - --num-partitions=4
+          - --base-rate=4000
           - --full-period=43200 # 12 hour cycle
         name: faker
         ports:

--- a/pkg/predictors/naive.go
+++ b/pkg/predictors/naive.go
@@ -40,7 +40,7 @@ func (s *NaivePredictor) estimateMemory(ramPerCore int64, cpuL int64) (int64, in
 	return limit, limit
 }
 
-func (s *NaivePredictor) Estimate(containerName string, partitions []int32) *corev1.ResourceRequirements {
+func (s *NaivePredictor) Estimate(_ string, partitions []int32) *corev1.ResourceRequirements {
 	var expectedConsumption int64
 	for _, p := range partitions {
 		expectedConsumption += s.expectedConsumption(p)


### PR DESCRIPTION
Always include iLimit/gLimit results in estimations. Split estimate func into "estimate" and "applyLimiters" to have clear separation of actions and be able to log "real" estimation.