### PR TITLE
Implement fallback strategy when there is no metrics

### DIFF
--- a/api/v1/consumer_types.go
+++ b/api/v1/consumer_types.go
@@ -22,6 +22,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// FallbackStrategy specifies how resources should be assigned
+// in case of missing Prometheus metrics.
+// Currently, two strategies are implemented: min and max
+type FallbackStrategy string
+
 type AutoscalerType string
 
 // ContainerScalingMode controls whether autoscaler is enabled for a specific
@@ -37,6 +42,9 @@ const (
 	ContainerScalingModeAuto ContainerScalingMode = "Auto"
 	// ContainerScalingModeOff means autoscaling is disabled for a container.
 	ContainerScalingModeOff ContainerScalingMode = "Off"
+
+	FallbackStrategyMin = "min"
+	FallbackStrategyMax = "max"
 )
 
 // ConsumerSpec defines the desired state of Consumer
@@ -110,6 +118,8 @@ type PrometheusAutoscalerSpec struct {
 	Offset      OffsetQuerySpec      `json:"offset"`
 	Production  ProductionQuerySpec  `json:"production"`
 	Consumption ConsumptionQuerySpec `json:"consumption"`
+	// +optional
+	FallbackStrategy *FallbackStrategy `json:"fallbackStrategy,omitempty"`
 
 	RatePerCore *int64            `json:"ratePerCore"`
 	RamPerCore  resource.Quantity `json:"ramPerCore"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -350,6 +350,11 @@ func (in *PrometheusAutoscalerSpec) DeepCopyInto(out *PrometheusAutoscalerSpec) 
 	out.Offset = in.Offset
 	out.Production = in.Production
 	out.Consumption = in.Consumption
+	if in.FallbackStrategy != nil {
+		in, out := &in.FallbackStrategy, &out.FallbackStrategy
+		*out = new(FallbackStrategy)
+		**out = **in
+	}
 	if in.RatePerCore != nil {
 		in, out := &in.RatePerCore, &out.RatePerCore
 		*out = new(int64)

--- a/config/crd/bases/konsumerator.lwolf.org_consumers.yaml
+++ b/config/crd/bases/konsumerator.lwolf.org_consumers.yaml
@@ -98,6 +98,11 @@ spec:
                         x-kubernetes-int-or-string: true
                       criticalLag:
                         type: string
+                      fallbackStrategy:
+                        description: 'FallbackStrategy specifies how resources should
+                          be assigned in case of missing Prometheus metrics. Currently,
+                          two strategies are implemented: min and max'
+                        type: string
                       minSyncPeriod:
                         type: string
                       offset:

--- a/controllers/consumer_test.go
+++ b/controllers/consumer_test.go
@@ -13,10 +13,6 @@ import (
 	konsumeratorv1 "github.com/lwolf/konsumerator/api/v1"
 )
 
-func TestEstimateResources(t *testing.T) {
-
-}
-
 func TestNewConsumerOperator(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/hack/ci/consumer-test-configmap.yaml
+++ b/hack/ci/consumer-test-configmap.yaml
@@ -34,6 +34,7 @@ data:
         # available, consumer will be scaled up to recover during
         # during this time.
         recoveryTime: "30m"
+        fallbackStrategy: "max"
         # prometheus addresses to query
         address:
           - "http://prometheus-server.kube-system:9090"

--- a/pkg/providers/prometheus.go
+++ b/pkg/providers/prometheus.go
@@ -165,7 +165,7 @@ func (l *PrometheusMP) query(api *promAPI, ctx context.Context, query string) (m
 	start := time.Now()
 	value, warnings, err := api.client.Query(ctx, query, time.Now())
 	if err != nil {
-		if ctx.Err() != context.Canceled {
+		if !errors.Is(err, context.Canceled) {
 			subRequestErrors.WithLabelValues(l.consumer, api.addr).Inc()
 		}
 		return nil, err
@@ -195,7 +195,7 @@ func (l *PrometheusMP) queryAll(query string) model.Value {
 			defer wg.Done()
 			v, err := l.query(prom, ctx, query)
 			if err != nil {
-				if ctx.Err() != context.Canceled {
+				if !errors.Is(err, context.Canceled) {
 					l.log.Error(err, "failed to query prometheus")
 				}
 				return


### PR DESCRIPTION
Add new field to the spec - `fallbackStrategy` that controlls what amount of resources should be assigned to the instance when it's impossible to run estimations due to missing metrics.

Only two modes are implemented at the moment - min and max, with default being min (to preserve the existing behaviour).

Fallback strategy assigns min/max value based on either of 2 inputs:

* if there are more than half of the instances are running (and more than 10 in total), find min/max among those instances and use it as fallback value for new estimations.

* otherwise, use min/max from the container policy set in the spec: 

  ``` containerPolicies:
	 - containerName: name
	     minAllowed: 
               cpu: 3
               memory: 12Gi
            maxAllowed:
               cpu: 8
               memory: 12Gi 
 ```