### PR TITLE
Workaround partially missing prometheus metrics

### DIFF
--- a/pkg/predictors/naive_test.go
+++ b/pkg/predictors/naive_test.go
@@ -217,6 +217,23 @@ func TestEstimateResources(t *testing.T) {
 				},
 			},
 		},
+		"estimation with missing metrics (multiple partitions)": {
+			containerName: "test",
+			promSpec:      *genPromSpec(10000, resource.MustParse("1G")),
+			lagStore:      NewMockProvider(map[int32]int64{0: 20000, 1: 10000}, map[int32]int64{0: 20001, 1: 20001}, map[int32]int64{0: 0}),
+			partitions:    []int32{0, 1, 2, 3},
+			fallback:      nil,
+			expectedResources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("7"),
+					corev1.ResourceMemory: resource.MustParse("7G"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("7"),
+					corev1.ResourceMemory: resource.MustParse("7G"),
+				},
+			},
+		},
 		"low production rate": {
 			containerName: "test",
 			promSpec:      *genPromSpec(10000, resource.MustParse("1G")),


### PR DESCRIPTION
Workaround partially missing metrics.
e.g. if we have a list of 4 partitions with metrics missing for 2 out of 4, like [10,11,0,0], resulting "expectedConsumption will be sum
 of [10,11,11,11]