### PR TITLE
Fix state machine when instances stuck in SATURATED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 .PHONY: controller-gen $(CONTROLLER_GEN)
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	$(LOCALBIN)/controller-gen --version | fgrep "$(CONTROLLER_TOOLS_VERSION)" || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+	$(LOCALBIN)/controller-gen --version | grep -F "$(CONTROLLER_TOOLS_VERSION)" || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/pkg/providers/prometheus.go
+++ b/pkg/providers/prometheus.go
@@ -125,6 +125,7 @@ func (l *PrometheusMP) GetLagByPartition(partition int32) time.Duration {
 	behind := l.GetMessagesBehind(partition)
 	production := l.GetProductionRate(partition)
 	if production == 0 {
+		lagObserved.WithLabelValues(l.consumer, strconv.Itoa(int(partition))).Set(0)
 		return 0
 	}
 	lagM := float64(behind) / float64(production)


### PR DESCRIPTION
There is a case when we need to explicitely reset SATURATED state.

If estimation returns `eq` or `gt` and some amount of resources got cut by any of the limiters, instances will continue to run in SATURATED state, even when there is no lag. Fix this by explicitely cleaning up "saturation".